### PR TITLE
django.models.EnumField: fix AttributeError at makemigrations

### DIFF
--- a/utils/django/models.py
+++ b/utils/django/models.py
@@ -33,6 +33,13 @@ class EnumField(models.SmallIntegerField):
 
         return self.enum_class(super().to_python(value))
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(EnumField, self).deconstruct()
+        if 'choices' in kwargs:
+            kwargs.pop('choices')
+        kwargs['enum_class'] = self.enum_class
+        return name, path, args, kwargs
+
 
 def enum2choices(enum):
     return [(item, item.name) for item in enum]


### PR DESCRIPTION
Ранее деконструирование поля приводило к его описанию в миграции вида
`EnumField(choices=[(smp_base_django.models.Medium(1), 'facebook'), (smp_base_django.models.Medium(2), 'instagram'), ...])`
 это могло приводить к AttributeError при создании последующих миграцию в случае изменения состава Enum-класса, а также к генерированию AlterField миграций при изменении состава Enum-класса. Теперь деконструированное поле будет сразу иметь вид
`EnumField(choices_enum=Medium)`