### PR TITLE
utils.log_config: update due to graypy refactoring

### DIFF
--- a/utils/log_config.py
+++ b/utils/log_config.py
@@ -77,7 +77,7 @@ class LoggingConfig(dict):
 
         # GELF UDP handler
         self.add_handler('gelf', {
-            'class': 'graypy.GELFHandler',
+            'class': 'graypy.GELFUDPHandler',
             'host': os.environ.get('GELF_HOST'),
             'port': int(os.environ.get('GELF_PORT', 12201)),
             'debugging_fields': False,


### PR DESCRIPTION
https://github.com/severb/graypy/issues/105
> Sorry for breaking compatibility, `GELFHandler` has been replaced with `GELFUDPHandler` to be more explicit on its implementation (and possibly highlighting the potential issues with sending logs via UDP).
> 
> **Note:** Similar changes were done with `GELFTcpHandler` being restructured into `GELFTCPHandler` and `GELFTLSHandler` to improve explicitness.
> 
> Any version of graypy 0.X.X should support the old definition of `GELFHandler` and `GELFTcpHandler`. Any version of 1.X.X does not support `GELFHandler` and `GELFTcpHandler`.

