### PR TITLE
django.settings: add DEFAULT_AUTO_FIELD for Django 3.2

### DIFF
--- a/utils/django/settings.py
+++ b/utils/django/settings.py
@@ -81,6 +81,8 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_SCHEME', 'https')
 ###
 # General
 ###
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 INSTALLED_APPS = [
     PROJECT_NAME + '.App',
 ]


### PR DESCRIPTION
There is a a new warning Since Django 3.2:
```
WARNINGS:
page.Page: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the App.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
page.Subscription: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the App.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```

According to [Django docs](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys):
> Maintaining the historical behavior, the default value for DEFAULT_AUTO_FIELD is AutoField. Starting with 3.2 new projects are generated with DEFAULT_AUTO_FIELD set to BigAutoField. Also, new apps are generated with AppConfig.default_auto_field set to BigAutoField. In a future Django release the default value of DEFAULT_AUTO_FIELD will be changed to BigAutoField.
>
> To avoid unwanted migrations in the future, either explicitly set DEFAULT_AUTO_FIELD to AutoField: