### PR TITLE
#SMP-289 provide EnumField value instead of enum #SMP-289

### DIFF
--- a/utils/django/serializers/fields.py
+++ b/utils/django/serializers/fields.py
@@ -30,7 +30,7 @@ class ChoiceDisplayField(ChoiceField):
             return ''
 
         try:
-            return self.choice_names_to_values[str(data)]
+            return self.choice_names_to_values[str(data)].value
         except KeyError:
             self.fail('invalid_choice', input=data)
 


### PR DESCRIPTION
Universal solution for **#SMP-289** issue, if other serializers with `EnumField` won't suffer from this fix, then this **PR** should be merged instead of [this](https://github.com/smpio/smp-client-vk/pull/39)